### PR TITLE
Add template tag

### DIFF
--- a/client/posts/strip-html-from-a-given-text/index.tsx
+++ b/client/posts/strip-html-from-a-given-text/index.tsx
@@ -44,6 +44,18 @@ const stripHtml = function(html) {
     return doc.body.textContent || "";
 };
 ~~~
+
+## 3. Use template
+
+The [\`<template>\`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) holds a HTML content that is not to be rendered immediately. However, this is not supported on older browser such as IE11.
+
+~~~ javascript
+const stripHtml = function(html) {
+  const ele = document.createElement('template');
+  ele.innerHTML = html;
+  return ele.content.textContent || "";
+};
+~~~
 `}
 />
 <RelatedPosts


### PR DESCRIPTION
<template> can be another great and more performant alternative when comes to stripping off HTML from given text. However it is part of the Web Components specs and it is not supported by older browser such IE11.