### PR TITLE
Cannot use multiple parameters in IE 11

### DIFF
--- a/client/posts/add-or-remove-class-from-an-element/index.tsx
+++ b/client/posts/add-or-remove-class-from-an-element/index.tsx
@@ -10,19 +10,23 @@ export default () => {
     content={`
 ## Add a class to an element
 
+Note that multiple parameters for the \`add()\` [isn't supported](https://caniuse.com/#feat=classlist) in IE 11.
+
 ~~~ javascript
 ele.classList.add('class-name');
 
-// Add multiple classes
+// Add multiple classes (Not supported in IE 11)
 ele.classList.add('another', 'class', 'name');
 ~~~
 
 ## Remove a class from an element
 
+Note that multiple parameters for the \`remove()\` [isn't supported](https://caniuse.com/#feat=classlist) in IE 11.
+
 ~~~ javascript
 ele.classList.remove('class-name');
 
-// Remove multiple classes
+// Remove multiple classes (Not supported in IE 11)
 ele.classList.remove('another', 'class', 'name');
 ~~~
 


### PR DESCRIPTION
IE 11 does not support multiple parameters for the add() & remove() methods.
https://caniuse.com/#feat=classlist

Please change the format of the comments to suit your project's policies.