### PR TITLE
Fix: on running server scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "scripts": {
         "copy": "npm run copy:public && npm run copy:demo",
         "copy:public": "rimraf dist && mkdir dist && cp -rf public/* dist",
-        "copy:demo": "cp -rf demo dist && NODE_ENV=production postcss vendors/tailwind@1.1.4/tailwind.css -o dist/demo/styles.css",
+        "copy:demo": "cp -rf demo dist && SET NODE_ENV=production postcss vendors/tailwind@1.1.4/tailwind.css -o dist/demo/styles.css",
         "dev": "npm run copy && webpack --mode development",
         "dev-server": "npm run copy && webpack-dev-server",
         "build": "npm run copy && webpack --mode production && npm run export",


### PR DESCRIPTION
fixes #121 

the command : 
`cp -rf demo dist && NODE_ENV=production postcss vendors/tailwind@1.1.4/tailwind.css -o dist/demo/styles.css` is the cause of the issue because it is not compatible on windows environnement, so it will can added "SET" before "NODE_ENV" so the script will be compatible with windows environnement.
