### PR TITLE
fix: drag and drop jump

### DIFF
--- a/demo/drag-and-drop-element-in-a-list/index.html
+++ b/demo/drag-and-drop-element-in-a-list/index.html
@@ -13,7 +13,7 @@
     .placeholder {
         background-color: #edf2f7;
         border: 2px dashed #cbd5e0;
-        margin: 1rem 0;
+        margin-bottom: 1rem;
     }
     </style>
 </head>


### PR DESCRIPTION
If you drag the first element on the drag and drop example, the whole list will jump down by 1rem.
The rest of the items work fine because of CSS collapsing margins.