### PR TITLE
Change MouseEvent.which to MouseEvent.button

### DIFF
--- a/client/posts/distinguish-between-left-and-right-mouse-clicks/index.tsx
+++ b/client/posts/distinguish-between-left-and-right-mouse-clicks/index.tsx
@@ -16,9 +16,11 @@ The \`mousedown\` and \`mouseup\` event handlers let us know which mouse button 
 
 ~~~ javascript
 ele.addEventListener('mousedown', function(e) {
-    // e.which === 1: the left button is clicked
-    // e.which === 2: the middle button is clicked
-    // e.which === 3: the right button is clicked
+    // e.button === 0: the left button is clicked
+    // e.button === 1: the middle button is clicked
+    // e.button === 2: the right button is clicked
+    // e.button === 3: the `Browser Back` button is clicked
+    // e.button === 4: the `Browser Forward` button is clicked
 });
 ~~~
 `}


### PR DESCRIPTION
[MouseEvent.which](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which) is non-standard and should not be used. [MouseEvent.button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button) is the standard alternative.

