### PR TITLE
Removing reinitialisation inside mouseDownHandler

### DIFF
--- a/client/posts/drag-and-drop-element-in-a-list/index.tsx
+++ b/client/posts/drag-and-drop-element-in-a-list/index.tsx
@@ -55,7 +55,7 @@ let x = 0;
 let y = 0;
 
 const mouseDownHandler = function(e) {
-    const draggingEle = e.target;
+    draggingEle = e.target;
 
     // Calculate the mouse position
     const rect = draggingEle.getBoundingClientRect();


### PR DESCRIPTION
The reinitialisation of `draggingEle` variable inside mouseDownHandler function is causing an error in mouseMoveHandler.