### PR TITLE
Reset `isDraggingStarted`

### DIFF
--- a/client/posts/drag-and-drop-element-in-a-list/index.tsx
+++ b/client/posts/drag-and-drop-element-in-a-list/index.tsx
@@ -158,6 +158,8 @@ The placeholder will be [removed](/remove-an-element) as soon as the users drop 
 const mouseUpHandler = function() {
     // Remove the placeholder
     placeholder && placeholder.parentNode.removeChild(placeholder);
+    // Reset the flag
+    isDraggingStarted = false;
     
     ...
 };


### PR DESCRIPTION
We will need to reassign `isDraggingStarted` variable to false. The previous code only worked for the first dragged element and then stopped working after the User drags the second one.