### PR TITLE
do not rely on default size of canvas

### DIFF
--- a/client/posts/resize-an-image/index.tsx
+++ b/client/posts/resize-an-image/index.tsx
@@ -45,6 +45,8 @@ const resize = function(image, ratio) {
                 const context = canvas.getContext('2d');
                 const w = ele.width * ratio;
                 const h = ele.height * ratio;
+                canvas.width = w;
+                canvas.height = h;
                 context.drawImage(ele, 0, 0, w, h);
                 
                 // Get the data of resized image


### PR DESCRIPTION
By default the canvas has a size of 300 by 150 pixels, which will limit the size of output image