### PR TITLE
Remove event listeners on mouse up

### DIFF
--- a/posts/drag-to-scroll.md
+++ b/posts/drag-to-scroll.md
@@ -105,6 +105,9 @@ These CSS properties are reset when the mouse is released:
 
 ```js
 const mouseUpHandler = function() {
+    document.removeEventListener('mousemove', mouseMoveHandler);
+    document.removeEventListener('mouseup', mouseUpHandler);
+    
     ele.style.cursor = 'grab';
     ele.style.removeProperty('user-select');
 };


### PR DESCRIPTION
If event listeners arent removed on mouse up then user keeps scrolling after attempting to stop scrolling.