### PR TITLE
New post: Prevent the page from scrolling to an element when it is focused

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 .netlify
 .next
+out
 node_modules

--- a/components/markdown/Heading2.tsx
+++ b/components/markdown/Heading2.tsx
@@ -5,7 +5,6 @@ const Heading2 = (props) => (
     <>
         <Spacer size="medium" />
         <Heading level={2}>{props.children}</Heading>
-        <Spacer size="small" />
     </>
 );
 

--- a/components/markdown/Heading3.tsx
+++ b/components/markdown/Heading3.tsx
@@ -5,7 +5,6 @@ const Heading3 = (props) => (
     <>
         <Spacer size="medium" />
         <Heading level={3}>{props.children}</Heading>
-        <Spacer size="small" />
     </>
 );
 

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -29,6 +29,8 @@ const PostPage: React.FC<PostPageProps> = ({ content, frontMatter, prevPost, nex
             <Spacer size="medium" />
             <Pagination>
                 {prevPost && <PrevPagination href={`/${prevPost.slug}`}>{prevPost.title}</PrevPagination>}
+            </Pagination>
+            <Pagination>
                 {nextPost && <NextPagination href={`/${nextPost.slug}`}>{nextPost.title}</NextPagination>}
             </Pagination>
         </PostLayout>

--- a/posts/prevent-the-page-from-scrolling-to-an-element-when-it-is-focused.md
+++ b/posts/prevent-the-page-from-scrolling-to-an-element-when-it-is-focused.md
@@ -1,0 +1,37 @@
+---
+category: Basic
+keywords:
+title: Prevent the page from scrolling to an element when it is focused
+---
+
+An element can be focused by either using the `autofocus="true"` attribute or calling the `element.focus()` method. In both cases, the browser will automatically scroll the element into the viewport.
+It is not a problem in most cases but I have seen a few scenarios where we would like to avoid the behaviour.
+
+For example, focusing on a text field inside a modal automatically might scroll the page to the top.
+
+There are two solutions to prevent this behaviour.
+
+### Use the preventScroll option
+
+We can pass the `preventScroll` option to the `focus()` method as following:
+
+```js
+element.focus({
+    preventScroll: true,
+});
+```
+
+However, the option is not fully supported in all browsers. Check out the [web-platform-tests](https://wpt.fyi/results/html/interaction/focus/processing-model/preventScroll.html) and [Can I use](https://caniuse.com/mdn-api_htmlelement_focus_preventscroll_option) pages.
+
+### Scroll to the previous point
+
+This approach works in all browsers. We store the mouse location before calling the `focus()` method, and then scroll to that location later:
+
+```js
+const x = window.scrollX;
+const y = window.scrollY;
+elem.focus();
+
+// Scroll to the previous location
+window.scrollTo(x, y);
+```

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -121,4 +121,5 @@
     <url><loc>https://htmldom.dev/show-a-custom-context-menu-at-clicked-position/</loc></url>
     <url><loc>https://htmldom.dev/show-or-hide-table-columns/</loc></url>
     <url><loc>https://htmldom.dev/zoom-an-image/</loc></url>
+    <url><loc>https://htmldom.dev/prevent-the-page-from-scrolling-to-an-element-when-it-is-focused/</loc></url>
 </urlset>


### PR DESCRIPTION
https://htmldom.dev/prevent-the-page-from-scrolling-to-an-element-when-it-is-focused/