### PR TITLE
Use replaceChildren() to clear child nodes

### DIFF
--- a/contents/remove-all-children-of-a-node.mdx
+++ b/contents/remove-all-children-of-a-node.mdx
@@ -23,6 +23,14 @@ while (node.firstChild) {
 }
 ```
 
+## 3. Replace the child nodes
+
+Replace its child nodes with... nothing:
+
+```js
+node.replaceChildren();
+```
+
 ## See also
 
 -   [Remove an element](https://phuoc.ng/collection/html-dom/remove-an-element/)


### PR DESCRIPTION
The `replaceChildren()` node with no parameters can be used to quickly clear a node's children:

https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren#emptying_a_node